### PR TITLE
Abandoned: Feature/units

### DIFF
--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -73,6 +73,7 @@ const QwickMaffs = {
             sin: Math.sin,
             cos: Math.cos,
         },
+        units: [],
     },
     Error: {
         UnbalancedParenthesis: 1,
@@ -84,7 +85,8 @@ const QwickMaffs = {
     /**
      * Takes a string containing either a number or a simple numeric expression
      */
-    exec: exec,
+    exec,
+    convert,
 };
 function exec(str, opts) {
     const normalizedOpts = normalizeOpts(opts);
@@ -385,5 +387,21 @@ function optimizeOps(ops) {
         lookup[op.op].push(op);
     }
     return lookup;
+}
+function convert(value, unit) {
+    if (typeof value === 'number') {
+        if (unit === null)
+            return value;
+        return {
+            value,
+            unit,
+        };
+    }
+    if (unit === null)
+        return value.value;
+    return {
+        value: value.value * unit.from[value.unit.name],
+        unit: unit,
+    };
 }
 export default QwickMaffs;

--- a/dist/esm/units/physicalSize.js
+++ b/dist/esm/units/physicalSize.js
@@ -1,0 +1,22 @@
+const allUnits = [
+    {
+        name: 'm',
+        si: true,
+        from: {
+            ft: 0.3048,
+        },
+    },
+    {
+        name: 'ft',
+        from: {
+            m: 1 / 0.3048,
+        },
+        alias: {
+            yd: 3,
+            mi: 5280,
+            in: 1 / 12,
+        },
+    },
+];
+export default allUnits;
+export const lookup = Object.fromEntries(allUnits.map((unit) => [unit.name, unit]));

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -15,8 +15,11 @@ declare const QwickMaffs: {
      * Takes a string containing either a number or a simple numeric expression
      */
     exec: typeof exec;
+    convert: typeof convert;
 };
 declare function exec(str: string, opts?: Partial<QMOpts>): number | QMError;
+declare function convert(value: number | QMValue, unit: null, units: QMUnit[]): number;
+declare function convert(value: number | QMValue, unit: QMUnit, units: QMUnit[]): QMValue;
 export default QwickMaffs;
 export interface QMOpts {
     /**
@@ -48,7 +51,15 @@ export interface QMOpts {
      * parameters.
      */
     functions: Record<string, (...nums: number[]) => number>;
+    /**
+     *
+     */
+    units: QMUnit[];
 }
+export type QMValue = {
+    value: number;
+    unit: QMUnit;
+};
 export type QMError = {
     error: number;
     pos: number;
@@ -60,3 +71,11 @@ export type QMOp = {
     precedence: number;
     apply: ((num: number) => number) | ((x: number, y: number) => number);
 };
+type QMUnit = {
+    name: string;
+    from: Record<string, number>;
+} & ({
+    si: true;
+} | {
+    alias: Record<string, number>;
+});

--- a/dist/umd/index.js
+++ b/dist/umd/index.js
@@ -95,6 +95,7 @@ var __assign = (this && this.__assign) || function () {
                 sin: Math.sin,
                 cos: Math.cos,
             },
+            units: [],
         },
         Error: {
             UnbalancedParenthesis: 1,
@@ -107,6 +108,7 @@ var __assign = (this && this.__assign) || function () {
          * Takes a string containing either a number or a simple numeric expression
          */
         exec: exec,
+        convert: convert,
     };
     function exec(str, opts) {
         var normalizedOpts = normalizeOpts(opts);
@@ -407,6 +409,22 @@ var __assign = (this && this.__assign) || function () {
             lookup[op.op].push(op);
         }
         return lookup;
+    }
+    function convert(value, unit) {
+        if (typeof value === 'number') {
+            if (unit === null)
+                return value;
+            return {
+                value: value,
+                unit: unit,
+            };
+        }
+        if (unit === null)
+            return value.value;
+        return {
+            value: value.value * unit.from[value.unit.name],
+            unit: unit,
+        };
     }
     exports.default = QwickMaffs;
 });

--- a/dist/umd/units/physicalSize.js
+++ b/dist/umd/units/physicalSize.js
@@ -1,0 +1,35 @@
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.lookup = void 0;
+    var allUnits = [
+        {
+            name: 'm',
+            si: true,
+            from: {
+                ft: 0.3048,
+            },
+        },
+        {
+            name: 'ft',
+            from: {
+                m: 1 / 0.3048,
+            },
+            alias: {
+                yd: 3,
+                mi: 5280,
+                in: 1 / 12,
+            },
+        },
+    ];
+    exports.default = allUnits;
+    exports.lookup = Object.fromEntries(allUnits.map(function (unit) { return [unit.name, unit]; }));
+});

--- a/dist/units/physicalSize.d.ts
+++ b/dist/units/physicalSize.d.ts
@@ -1,0 +1,45 @@
+declare const allUnits: ({
+    name: string;
+    si: boolean;
+    from: {
+        ft: number;
+        m?: undefined;
+    };
+    alias?: undefined;
+} | {
+    name: string;
+    from: {
+        m: number;
+        ft?: undefined;
+    };
+    alias: {
+        yd: number;
+        mi: number;
+        in: number;
+    };
+    si?: undefined;
+})[];
+export default allUnits;
+export declare const lookup: {
+    [k: string]: {
+        name: string;
+        si: boolean;
+        from: {
+            ft: number;
+            m?: undefined;
+        };
+        alias?: undefined;
+    } | {
+        name: string;
+        from: {
+            m: number;
+            ft?: undefined;
+        };
+        alias: {
+            yd: number;
+            mi: number;
+            in: number;
+        };
+        si?: undefined;
+    };
+};

--- a/src/units/physicalSize.ts
+++ b/src/units/physicalSize.ts
@@ -1,4 +1,4 @@
-export default [
+const allUnits = [
 	{
 		name: 'm',
 		si: true,
@@ -18,3 +18,8 @@ export default [
 		},
 	},
 ];
+
+export default allUnits;
+export const lookup = Object.fromEntries(
+	allUnits.map((unit) => [unit.name, unit]),
+);

--- a/src/units/physicalSize.ts
+++ b/src/units/physicalSize.ts
@@ -1,11 +1,13 @@
-export default {
-	m: {
+export default [
+	{
+		name: 'm',
 		si: true,
 		from: {
 			ft: 0.3048,
 		},
 	},
-	ft: {
+	{
+		name: 'ft',
 		from: {
 			m: 1 / 0.3048,
 		},
@@ -15,4 +17,4 @@ export default {
 			in: 1 / 12,
 		},
 	},
-};
+];

--- a/src/units/physicalSize.ts
+++ b/src/units/physicalSize.ts
@@ -1,0 +1,18 @@
+export default {
+	m: {
+		si: true,
+		from: {
+			ft: 0.3048,
+		},
+	},
+	ft: {
+		from: {
+			m: 1 / 0.3048,
+		},
+		alias: {
+			yd: 3,
+			mi: 5280,
+			in: 1 / 12,
+		},
+	},
+};

--- a/src/units/physicalSize.ts
+++ b/src/units/physicalSize.ts
@@ -1,3 +1,5 @@
+import type { QMUnit } from '../index';
+
 const allUnits = [
 	{
 		name: 'm',
@@ -17,7 +19,7 @@ const allUnits = [
 			in: 1 / 12,
 		},
 	},
-];
+] as QMUnit[];
 
 export default allUnits;
 export const lookup = Object.fromEntries(

--- a/tests/units.test.ts
+++ b/tests/units.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import QwickMaffs from '../src/index';
+import PhysicalUnits, { lookup } from '../src/units/physicalSize';
+
+describe('Units', () => {
+	test.each([
+		['1m', { value: 1, unit: lookup.m }],
+		['62m', { value: 62, unit: lookup.m }],
+		['62.2m', { value: 62.2, unit: lookup.m }],
+		['2km', { value: 2000, unit: lookup.m }],
+		['2mm', { value: 0.002, unit: lookup.m }],
+		['2mi', { value: 10560, unit: lookup.ft }],
+		['2m + 2', { value: 4, unit: lookup.m }],
+		['2dm + 6cm', { value: 0.26, unit: lookup.m }],
+		['2dm * 6m', { value: 0.2 * 6, unit: lookup.m }], // This is pretty wrong :/
+		['3m ^ 2', { value: 9, unit: lookup.m }], // But we don't support things like area
+	])('"%s" -> %o', (expression, result) => {
+		expect(QwickMaffs.exec(expression, { units: PhysicalUnits })).toMatchObject(
+			result,
+		);
+	});
+});

--- a/tests/units.test.ts
+++ b/tests/units.test.ts
@@ -14,6 +14,7 @@ describe('Units', () => {
 		['2dm + 6cm', { value: 0.26, unit: lookup.m }],
 		['2dm * 6m', { value: 0.2 * 6, unit: lookup.m }], // This is pretty wrong :/
 		['3m ^ 2', { value: 9, unit: lookup.m }], // But we don't support things like area
+		['1m + 1ft', { value: 1.3048, unit: lookup.m }],
 	])('"%s" -> %o', (expression, result) => {
 		expect(QwickMaffs.exec(expression, { units: PhysicalUnits })).toMatchObject(
 			result,


### PR DESCRIPTION
Adds support for measurement units.

This seemed like a good idea at the time, but properly supporting units would add a lot more code. The version implemented here somewhat works, but operators don't properly interact with units. E.g. `4m + 5` returns `9m` which might arguably be expected, but also `4m * 5m` is `20m`, which is just plainly the wrong unit. Basically, for every operation, it just takes the first unit and converts the other units to it, then just executes the function on the plain number values, then converts the value back to a unit value.

This branch will remain abandoned for the time being. The parser already has enough scuff as is.